### PR TITLE
test(lyrics-sync): 旧系統から IGNORE テスト一式とドキュメントを回収

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/bin/UX-Music.app/Contents/MacOS/UX-Music
 /src/sidecars/mtp/node_modules
 *.md5
 
+# python/lyrics_sync ソースは追跡する — 仮想環境とメタデータのみ除外
 /IGNORE/
 python/.venv/
 *.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ APP_BUNDLE = build/bin/UX-Music.app
 RESOURCES_BIN = $(APP_BUNDLE)/Contents/Resources/bin
 SWIFT_SIDECAR_BIN = swift/lyrics-sync/.build/release/lyrics-sync-swift
 
-.PHONY: build dev clean lyrics-sync-python test test-go test-renderer test-python
+.PHONY: build dev clean lyrics-sync-python test test-go test-renderer test-python test-lyrics-sync test-lyrics-sync-ignore-e2e
 
 # ローカルで CI と同じテストを回すための導線。
 # CI 側の定義は .github/workflows/test.yml。
@@ -40,3 +40,13 @@ lyrics-sync-python:
 
 clean:
 	rm -rf build/bin
+
+# 軽量（IGNORE/lyrics.txt・*.flac があればそれも検証）。
+test-lyrics-sync:
+	cd python && python3 -m pytest tests/ -m "not heavy" -v
+
+# 重い: Demucs + Whisper。IGNORE に lyrics.txt と FLAC を置き、次を指定して実行してください。
+#   export UX_MUSIC_IGNORE_INTEGRATION=1
+#   （任意） export UX_MUSIC_IGNORE_TEST_WHISPER_MODEL=base
+test-lyrics-sync-ignore-e2e:
+	cd python && UX_MUSIC_IGNORE_INTEGRATION=1 python3 -m pytest tests/test_ignore_pipeline_integration.py -m heavy -v --tb=short

--- a/markdown/testing-lyrics-sync.md
+++ b/markdown/testing-lyrics-sync.md
@@ -89,20 +89,16 @@ cd python && UX_MUSIC_IGNORE_INTEGRATION=1 python3 -m pytest tests/test_ignore_p
 | `ignore_assets.py` | リポジトリルート基準で `IGNORE/` のパス・歌詞読み込み・結合フラグ判定 |
 | `test_ignore_local_assets.py` | `lyrics.txt` / FLAC が存在するときのみ走る軽い検証（キーフレーズ・`soundfile` で FLAC ヘッダ） |
 | `test_ignore_pipeline_integration.py` | 上記 `heavy` 結合。環境変数とアセット両方が揃わない場合は skip |
-| `test_stage2_asr_hints.py` | Whisper に渡す **`initial_prompt` / hotwords`** 用文字列や言語ヒント生成の単体検証 |
-| `test_stage3_align_monotone.py` | **`_monotone_greedy_ranges`** と **`_pick_start_word`** の行列・スタブ前提の単体検証 |
+
+整列処理の単体テストは `test_stage3_large_jump_repair.py` / `test_stage3_interpolate.py` / `test_stage3_align_end_to_end.py` / `test_sync_accuracy_metrics.py` を参照。
 
 加えて **`python/tests/test_pipeline_dummy.py`** は `test_*` 関数を持たないため **`pytest` では収集されない**。`python3 python/tests/test_pipeline_dummy.py` のように実行すると、`UX_MUSIC_LYRICS_SYNC_DUMMY=1` で CLI の subprocess を通すスタンドアロンのスモークになる。
 
 ---
 
-## 5. Whisper 歌詞ヒント（本番・アプリ設定）
+## 5. Whisper 歌詞ヒント（未実装）
 
-自動同期本体の ASR では、入力歌詞から **`initial_prompt` / hotwords`** を組み立てる（詳細は `python/lyrics_sync/stage2_asr.py`）。結合テストでは直接は網羅しないが、挙動切り替え用に次がある。
-
-| 変数 | 意味 |
-|:---|:---|
-| `UX_MUSIC_WHISPER_LYRIC_PROMPT` | `0` / `false` / `no` で歌詞ベースの誘導をオフ |
+**現行の `python/lyrics_sync/stage2_asr.py` に歌詞ベースの ASR 誘導は実装されていない。** 入力歌詞から `initial_prompt` / hotwords を組み立てて Whisper を誘導する案は別ブランチで試作されたが、その後 `stage3_align` が大幅に作り直されたため取り込まれていない。試作は `origin/archive/lyrics-sync-old-main` の `ff33693` に残っている。経緯は `progress/lyrics-sync-asr-hint-deferred.md` を参照。
 
 ---
 

--- a/markdown/testing-lyrics-sync.md
+++ b/markdown/testing-lyrics-sync.md
@@ -1,0 +1,129 @@
+# 歌詞自動同期（Python サイドカー）のテスト
+
+自動歌詞同期パイプライン（`python/lyrics_sync/`）と、ローカル検証用アセット（`IGNORE/`）まわりのテスト実行手順をまとめる。処理仕様自体は [`lyrics-sync-plan.md`](./lyrics-sync-plan.md) を参照。
+
+---
+
+## 1. 構成の概要
+
+| 項目 | 内容 |
+|:---|:---|
+| テストルート | リポジトリ直下の **`python/tests/`**（`pytest` は **`python/`** をカレントにして実行する想定） |
+| import 経路 | `python/tests/conftest.py` が `sys.path` に **`python/`** を追加し、`lyrics_sync` を import 可能にしている |
+| マーカー | `heavy` は **Demucs、faster-whisper、埋め込みモデル**など重い処理を伴う結合テスト用（`pytest` で個別選択可能） |
+
+---
+
+## 2. クイックスタート（軽量テストのみ）
+
+依存は **`python/pyproject.toml`** の開発用オプション（`pytest` 等）および歌詞同期用ランタイム（`pip install -e '.[dev]'` などローカルの手順に従う）を満たすこと。
+
+リポジトリルートから:
+
+```bash
+make test-lyrics-sync
+```
+
+等価コマンド:
+
+```bash
+cd python && python3 -m pytest tests/ -m "not heavy" -v
+```
+
+**`heavy`** マーカ付きテストは上記では **収集のみ除外**される（または deselect される）。結合パイプラインは別途実行する（次節）。
+
+---
+
+## 3. 重い結合テスト（`IGNORE/` + E2E）
+
+### 3.1 目的
+
+`IGNORE/` に **`lyrics.txt`** と **`*.flac`**（ユーザーが用意した音声）があるときのみ、実際に **`run_pipeline`**（分離→ASR→整列）を走らせる。
+
+### 3.2 レイアウトの例
+
+- `IGNORE/lyrics.txt` … UTF-8。空行のみの行はテスト側で読み飛ばし、**非空行だけ**リクエストの `lines` に詰める。
+- `IGNORE/*.flac` … **`*.flac` / `*.FLAC`** を名前順で並べ、**先頭の 1 ファイル**だけを音声パスとして使う（例: `04 - アムネシア.flac`）。
+
+`/IGNORE` は **`.gitignore` に含まれる**。アセットはリポジトリにコミットされず、**各開発者マシンのローカル専用**とする。
+
+### 3.3 実行条件と環境変数
+
+結合テストは **`UX_MUSIC_IGNORE_INTEGRATION=1`** のときのみ実行される（実行せず明示的スキップする）。意図は **誤って CI で重い処理を動かさないこと** と **ローカルでの明示オプトイン**。
+
+| 変数 | 意味 |
+|:---|:---|
+| `UX_MUSIC_IGNORE_INTEGRATION` | `1` / `true` / `yes` のときのみ `heavy` のフルパイプライン試験が走る |
+
+任意:
+
+| 変数 | 意味 |
+|:---|:---|
+| `UX_MUSIC_IGNORE_TEST_WHISPER_MODEL` | 結合テスト内での Whisper モデル名（未設定時は `base` 相当の既定がある：実装側の **`test_ignore_pipeline_integration.py`** の説明どおり）。短時間での煙のみなら **`base`** など軽めの指定を検討。 |
+
+Makefile から実行する場合:
+
+```bash
+export UX_MUSIC_IGNORE_INTEGRATION=1
+# （任意）
+export UX_MUSIC_IGNORE_TEST_WHISPER_MODEL=base
+
+make test-lyrics-sync-ignore-e2e
+```
+
+手動での等価例:
+
+```bash
+cd python && UX_MUSIC_IGNORE_INTEGRATION=1 python3 -m pytest tests/test_ignore_pipeline_integration.py -m heavy -v --tb=short
+```
+
+**時間・ディスク・CPU/GPU に余裕がある環境のみ**実行すること。**初回**はモデル取得や ONNX 類のキャッシュによりさらに時間がかかる。
+
+---
+
+## 4. テストファイルの対応ざっくり表
+
+| ファイル | 内容 |
+|:---|:---|
+| `conftest.py` | `python/` をパスに追加 |
+| `ignore_assets.py` | リポジトリルート基準で `IGNORE/` のパス・歌詞読み込み・結合フラグ判定 |
+| `test_ignore_local_assets.py` | `lyrics.txt` / FLAC が存在するときのみ走る軽い検証（キーフレーズ・`soundfile` で FLAC ヘッダ） |
+| `test_ignore_pipeline_integration.py` | 上記 `heavy` 結合。環境変数とアセット両方が揃わない場合は skip |
+| `test_stage2_asr_hints.py` | Whisper に渡す **`initial_prompt` / hotwords`** 用文字列や言語ヒント生成の単体検証 |
+| `test_stage3_align_monotone.py` | **`_monotone_greedy_ranges`** と **`_pick_start_word`** の行列・スタブ前提の単体検証 |
+
+加えて **`python/tests/test_pipeline_dummy.py`** は `test_*` 関数を持たないため **`pytest` では収集されない**。`python3 python/tests/test_pipeline_dummy.py` のように実行すると、`UX_MUSIC_LYRICS_SYNC_DUMMY=1` で CLI の subprocess を通すスタンドアロンのスモークになる。
+
+---
+
+## 5. Whisper 歌詞ヒント（本番・アプリ設定）
+
+自動同期本体の ASR では、入力歌詞から **`initial_prompt` / hotwords`** を組み立てる（詳細は `python/lyrics_sync/stage2_asr.py`）。結合テストでは直接は網羅しないが、挙動切り替え用に次がある。
+
+| 変数 | 意味 |
+|:---|:---|
+| `UX_MUSIC_WHISPER_LYRIC_PROMPT` | `0` / `false` / `no` で歌詞ベースの誘導をオフ |
+
+---
+
+## 6. CI での運用の目安
+
+- **標準**: `make test-lyrics-sync`（`heavy` なし）のみ。`IGNORE/` が無ければ、アセット依存テストは **skip** で緑になりやすい。
+- **結合 E2E** は、アセット鍵や長時間ランが使えない限り **`UX_MUSIC_IGNORE_INTEGRATION` をセットしない**（またはワークフローから除外する）。
+- **`python/.venv`** や **`*.egg-info`** は一般的に無視される。ソースは **`python/lyrics_sync`** および **`python/tests`** が追跡対象となる（詳細はリポジトリの `.gitignore`）。
+
+---
+
+## 7. Go 側との関係
+
+`internal/lyricssync/` には **サイドカーとの stdin/stdout 契約用**の Go テストがある。**歌詞処理の論理単体試験は主に Python 側**に置く。**`go test ./...`** と **`make test-lyrics-sync`** は両方とも通せる状態を維持するのがよい。
+
+---
+
+## 8. 既知の限界（テストでも暗黙になりがち）
+
+- **`align()` を sentence-transformers まで通した本物の埋め込み**での回帰は、デフォルトの軽量 pytest セットにはほぼ含めていない。
+- **英語行の音素経路（`g2p_en` と NLTK データ）は**環境により失敗しうる。そのため **`_pick_start_word`** の一部は **`phoneme_tokens` をスタブ**しており、クリーン環境でも安定して動くようにしている。
+- 整列アルゴリズムの **単調グリード** と **間奏行がポインタを進めない仕様**は `test_stage3_align_monotone.py` で一部固定している。音声と歌詞が長尺・多言語になるほど **実データでの結合確認**が有効。
+
+以上を、開発者向けに「どこまでが自動検証されていて、結合試験には何が必要か」の境界として参照してほしい。

--- a/progress/INDEX.md
+++ b/progress/INDEX.md
@@ -1,5 +1,7 @@
 # Progress Index
 
+- [lyrics-sync-asr-hint-deferred.md](lyrics-sync-asr-hint-deferred.md) — 旧 lyrics-sync 系統（`origin/archive/lyrics-sync-old-main`）から拾うものの取捨。間奏付近の疎いASRセグメント抑制（`71c3e54`）は現行 `stage3_align`（202行→783行、`_repair_*` 5種＋`is_interlude`）が上位互換のため破棄、「Whisper に歌詞を `initial_prompt`/hotwords として渡す」（`ff33693`）は現行版に存在しない独自アイデアのため保留（cherry-pick 不可・現行実装への移植が必要）。IGNORE テスト一式とドキュメントのみ取り込み、`markdown/testing-lyrics-sync.md` の「機能が存在する前提」の記述を未実装と明記に修正
+
 - [licence-audit.md](licence-audit.md) — LICENSE を GPL-2.0 から GPL-3.0 へ変更（`b664b6f`）して解決済み。問題は直接依存の Apache-2.0 4つ（go-mp3 / go-audio/wav / go-audio/audio / purego）が FSF の見解で GPLv2 と非互換だったこと（Go は静的リンクで回避不可）。誤解の訂正として ffmpeg は同梱しておらず実行時に PATH から解決するため GPL の義務は発生しない。同梱 copyleft は cdparanoia（GPL-2.0、exec 起動なので伝播しない）のみで、`libkalam.dylib` はライセンス不明＝最大の未確認リスク
 
 - [flac-native-decoder.md](flac-native-decoder.md) — mewkiz/flac をやめて `pkg/audio/flac` に FLAC デコーダを自作する決定。理由は補助コードが自作デコーダ級に膨らんでいたこと（ID3v2 付き FLAC のための原本 remux＝破壊的書き換え、SeekTable 不在時の全フレームスキャン索引＋ディスクキャッシュ、`reflect`+`unsafe` による非公開フィールド注入）と、int16 固定インターフェースによる 24bit のディザなし切り捨て。Rust を却下したのはデコーダがオーディオコールバック外のゴルーチンで 150ms 先読み済み＝GC 論法が不成立、`go test -race` の検査外に出るコスト、Swift 側は AVFoundation で自前デコード不要＝共有先が無いため。検証は `flac -d` とのバイト一致＋STREAMINFO の MD5 自己検証の二重経路、フィクスチャは ffmpeg+flac CLI でその場生成。増分3でサブフレーム／Rice残差／ステレオデコリレーション／フレームCRC-16／公開APIを実装し全フィクスチャでビット完全一致に到達。二重バッファリングによる最終フレーム欠落バグを受け入れテストで検出・修正（`BitReader.AtEOF`追加）

--- a/progress/lyrics-sync-asr-hint-deferred.md
+++ b/progress/lyrics-sync-asr-hint-deferred.md
@@ -1,0 +1,44 @@
+# 歌詞で Whisper を誘導する案（保留中・未取り込み）
+
+## 決定
+
+**Whisper の ASR に入力歌詞をヒントとして与える案（`initial_prompt` / hotwords）を、現時点では取り込まない。** アイデア自体は有効だが、試作されたコードは現行の `stage3_align` より前の系統に載っており、そのまま cherry-pick すると古い整列ロジックを引き戻すため。
+
+試作は `origin/archive/lyrics-sync-old-main` の以下に保全してある。
+
+| コミット | 内容 | 扱い |
+|---|---|---|
+| `ff33693` | feat(lyrics-sync): Whisper を歌詞で誘導し行頭とASR語の対応を改善 | **保留（アイデアは有効・移植は未実施）** |
+| `71c3e54` | fix(lyrics-sync): 間奏付近の疎いASRセグメントを抑え埋め込み弱一致時は後方の音声へ再探索 | **破棄**（下記のとおり現行版が上位互換） |
+| `0094cb3` | test: stage3_align の実装に合わせて単体テストを更新 | **破棄**（旧実装に紐づくため） |
+
+## なぜ 71c3e54 を破棄したか
+
+`origin/main` 側の `stage3_align.py` は 783 行、旧系統は 202 行で、同じ問題領域に対して現行版が遥かに作り込まれている。現行版が持つ修復処理：
+
+- `_repair_large_jump_snap`
+- `_repair_isolated_gap_tail`
+- `_repair_repeated_block_tail_extension`
+- `_repair_forward_drift_to_skipped_segments`
+- `_enforce_monotone_progress`
+- `phoneme.is_interlude` による間奏行の一貫した除外
+
+旧系統の「間奏付近の疎いセグメント抑制・後方への再探索」はこれらに包含される。取り込む価値がない。
+
+## なぜ ff33693 は保留（破棄ではない）か
+
+現行の `stage2_asr.py` には**歌詞ベースの誘導が一切存在しない**（`initial_prompt` / hotwords / lyric いずれの参照もなし）。つまりこれは現行版に無い独自のアイデアで、失うと惜しい。
+
+ただし取り込みは cherry-pick ではなく**現行実装への移植**になる。試作コミットは `stage2_asr.py`（54 行）だけでなく `stage3_align.py`（161 行）と `pipeline.py` も同時に書き換えており、後者 2 つは現行版と全く別物だから。
+
+## 移植する場合にやること
+
+1. `ff33693` の `stage2_asr.py` 差分のみを参照し、歌詞から `initial_prompt` / hotwords を組み立てる処理を現行版へ書き直す。
+2. 挙動切り替えの環境変数 `UX_MUSIC_WHISPER_LYRIC_PROMPT`（`0`/`false`/`no` で無効）も併せて実装する。
+3. 単体テストを新規に書く（試作の `test_stage2_asr_hints.py` は旧実装の関数シグネチャ前提なので流用不可）。
+4. 効果測定は `python/tests/sync_accuracy.py` の指標で、移植前後を実アセットで比較する。ヒントが誤った語へ引っ張る副作用があり得るため、体感ではなく指標で確認すること。
+
+## 注意点
+
+- `markdown/testing-lyrics-sync.md` は当初この機能が存在する前提で書かれていた。実態に合わせて「未実装」と明記済み。移植したらこの記述も戻すこと。
+- 退避ブランチ `origin/archive/lyrics-sync-old-main` は、この移植が済むか、不要と判断されるまで削除しないこと。

--- a/python/tests/ignore_assets.py
+++ b/python/tests/ignore_assets.py
@@ -1,0 +1,50 @@
+"""IGNORE 直下のユーザー提供アセットを解決するヘルパー（リポジトリルート基準）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def ignore_directory() -> Path:
+    return repo_root() / "IGNORE"
+
+
+def lyrics_txt_path() -> Path:
+    return ignore_directory() / "lyrics.txt"
+
+
+def find_ignore_flac() -> Path | None:
+    directory = ignore_directory()
+    if not directory.is_dir():
+        return None
+    for pattern in ("*.flac", "*.FLAC"):
+        matches = sorted(directory.glob(pattern))
+        if matches:
+            return matches[0]
+    return None
+
+
+def load_lyrics_non_empty_lines(encoding: str = "utf-8") -> list[str]:
+    path = lyrics_txt_path()
+    text = path.read_text(encoding=encoding)
+    lines: list[str] = []
+    for raw in text.splitlines():
+        s = raw.strip("\ufeff").rstrip("\n\r")
+        if s.strip() == "":
+            continue
+        lines.append(s)
+    return lines
+
+
+def integration_env_enabled() -> bool:
+    import os
+
+    return os.environ.get("UX_MUSIC_IGNORE_INTEGRATION", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }

--- a/python/tests/test_ignore_local_assets.py
+++ b/python/tests/test_ignore_local_assets.py
@@ -1,0 +1,47 @@
+"""IGNORE 直下の lyrics.txt と FLAC が揃っているときに走る軽量テスト（モデル不要）。"""
+
+from __future__ import annotations
+
+import pytest
+
+from ignore_assets import (
+    find_ignore_flac,
+    ignore_directory,
+    load_lyrics_non_empty_lines,
+    lyrics_txt_path,
+)
+
+
+@pytest.mark.skipif(
+    not lyrics_txt_path().is_file(),
+    reason="IGNORE/lyrics.txt がありません（ローカル用アセット）",
+)
+def test_ignore_lyrics_utf8_and_key_phrase():
+    lines = load_lyrics_non_empty_lines()
+    assert len(lines) >= 10
+    blob = "\n".join(lines)
+    assert "眺めていた花が咲いた" in blob
+
+
+@pytest.mark.skipif(
+    not find_ignore_flac(),
+    reason="IGNORE 内に .flac がありません（ローカル用アセット）",
+)
+def test_ignore_flac_readable():
+    try:
+        import soundfile as sf
+    except ImportError:
+        pytest.skip("soundfile が未インストール")
+
+    path = find_ignore_flac()
+    assert path is not None
+    info = sf.info(str(path))
+    assert info.samplerate >= 8000
+    assert info.frames > 0
+
+
+def test_ignore_directory_documented():
+    """IGNORE が無い環境でも失敗にしない（CI 向け）。"""
+    d = ignore_directory()
+    if not d.is_dir():
+        pytest.skip("IGNORE ディレクトリがありません")

--- a/python/tests/test_ignore_pipeline_integration.py
+++ b/python/tests/test_ignore_pipeline_integration.py
@@ -1,0 +1,83 @@
+"""
+IGNORE の lyrics.txt + *.flac でフルパイプラインを検証する結合テスト。
+
+非常に重いです（Demucs / Whisper / 埋め込み）。既定ではスキップし、
+次のように有効化します。
+
+    export UX_MUSIC_IGNORE_INTEGRATION=1
+    # 任意: 速いモデル（既定は base）
+    export UX_MUSIC_IGNORE_TEST_WHISPER_MODEL=base
+
+    cd リポジトリルート
+    PYTHONPATH=python pytest python/tests/test_ignore_pipeline_integration.py -m heavy -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ignore_assets import (
+    find_ignore_flac,
+    integration_env_enabled,
+    load_lyrics_non_empty_lines,
+    lyrics_txt_path,
+)
+
+
+pytestmark = pytest.mark.heavy
+
+
+def _skip_if_not_ready():
+    if not lyrics_txt_path().is_file():
+        pytest.skip("IGNORE/lyrics.txt がありません")
+    flac = find_ignore_flac()
+    if not flac:
+        pytest.skip("IGNORE 内に .flac がありません")
+    if not integration_env_enabled():
+        pytest.skip(
+            "UX_MUSIC_IGNORE_INTEGRATION=1 のときだけ実行します（フルパイプラインは重い）"
+        )
+
+
+@pytest.fixture
+def no_lyrics_dummy(monkeypatch):
+    monkeypatch.delenv("UX_MUSIC_LYRICS_SYNC_DUMMY", raising=False)
+
+
+def test_ignore_full_pipeline_amnesia(no_lyrics_dummy, monkeypatch):
+    _skip_if_not_ready()
+
+    whisper = os.environ.get("UX_MUSIC_IGNORE_TEST_WHISPER_MODEL", "base").strip() or "base"
+    monkeypatch.setenv("UX_MUSIC_WHISPER_MODEL", whisper)
+
+    from lyrics_sync.pipeline import run_pipeline
+
+    lines = load_lyrics_non_empty_lines()
+    flac = find_ignore_flac()
+    assert flac is not None
+
+    staged: list[tuple[str, float]] = []
+
+    def emit(stage: str, pct: float) -> None:
+        staged.append((stage, pct))
+
+    result = run_pipeline(
+        {"songPath": str(flac), "lines": lines, "whisperModel": whisper},
+        emit=emit,
+    )
+
+    assert result.get("success") is True, result.get("error", result)
+    assert isinstance(result.get("lines"), list)
+    matched = sum(1 for row in result["lines"] if row.get("source") == "match")
+    assert matched >= 1, "少なくとも1行は Whisper 単語タイムスタンプへマッチが必要"
+
+    keyed = [
+        row
+        for row in result["lines"]
+        if "眺めていた花が咲いた" in str(row.get("text", ""))
+    ]
+    assert len(keyed) >= 1
+    ts = float(keyed[0].get("timestamp", -99.0))
+    assert ts >= 0.0


### PR DESCRIPTION
`origin/archive/lyrics-sync-old-main`（旧ローカル `main`）に取り残されていた 5 コミットのうち、現行実装と衝突しない有用な分のみを回収します。

## 取り込むもと

- `01955fb` IGNORE の lyrics/FLAC 用テストと make ターゲット（`ignore_assets.py` / `test_ignore_local_assets.py` / `test_ignore_pipeline_integration.py`、`make test-lyrics-sync` ほか）
- `4c41566` テスト実行手順のドキュメント

## 取り込まないもの

- `71c3e54`（間奏付近の疎い ASR セグメント抑制）— 現行 `stage3_align` が上位互換（202行→783行、`_repair_*` 5種）のため**破棄**
- `ff33693`（Whisper を歌詞で誘導）— 現行版に無い独自アイデアだが、cherry-pick では旧整列ロジックを引き戻すため**保留**。移植手順を `progress/lyrics-sync-asr-hint-deferred.md` に記録
- `0094cb3`（旧実装に紐づくテスト更新）— **破棄**

## 補足

`markdown/testing-lyrics-sync.md` は歌詞ヒント機能が存在する前提で書かれていたため、実態に合わせて「未実装」と明記しました。

`pytest` 43 passed / 6 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)