### PR TITLE
fix: 設定画面のライセンス一覧を実態に合わせて修正・補完

### DIFF
--- a/main_licence_list_test.go
+++ b/main_licence_list_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLicenceListContainsAllLinkedModules は、実際にバイナリへリンクされている
+// Go モジュールがすべて設定画面のライセンス一覧（src/renderer/index.html）に
+// 記載されていることを保証する。一覧のドリフト（モジュール追加時の記載漏れ）を
+// 早期に検知するための回帰テスト。
+//
+// 逆方向（一覧にあるものが全てリンクされている）は意図的に検証しない。
+// 一覧には同梱ネイティブバイナリや、現在の OS ではリンクされないプラットフォーム
+// 固有モジュールの記載が正当に含まれるため。
+func TestLicenceListContainsAllLinkedModules(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go バイナリが PATH に存在しないためスキップ")
+	}
+
+	cmd := exec.Command("go", "list", "-deps", "-f", "{{with .Module}}{{.Path}}{{end}}", ".")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list -deps の実行に失敗しました: %v", err)
+	}
+
+	htmlPath := filepath.Join("src", "renderer", "index.html")
+	htmlBytes, err := os.ReadFile(htmlPath)
+	if err != nil {
+		t.Fatalf("%s の読み込みに失敗しました: %v", htmlPath, err)
+	}
+	html := string(htmlBytes)
+
+	var missing []string
+	for _, line := range strings.Split(string(out), "\n") {
+		modulePath := strings.TrimSpace(line)
+		if modulePath == "" || modulePath == "ux-music-sidecar" {
+			continue
+		}
+		if !strings.Contains(html, modulePath) {
+			missing = append(missing, modulePath)
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Fatalf("リンクされているが %s に記載されていない Go モジュールがあります:\n  %s",
+			htmlPath, strings.Join(missing, "\n  "))
+	}
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -547,6 +547,15 @@
                             <summary>ライセンス情報</summary>
                             <div class="licence-scroll">
                                 <section class="licence-section">
+                                    <h5>UX Music</h5>
+                                    <dl class="licence-list">
+                                        <div class="licence-entry">
+                                            <dt>UX Music</dt>
+                                            <dd><span class="licence-badge">GPL-3.0</span> UX Music Project</dd>
+                                        </div>
+                                    </dl>
+                                </section>
+                                <section class="licence-section">
                                     <h5>バンドルバイナリ</h5>
                                     <dl class="licence-list">
                                         <div class="licence-entry">
@@ -554,20 +563,25 @@
                                             <dd><span class="licence-badge">GPL-2.0</span> Monty Montgomery &amp; the Xiph.Org Foundation</dd>
                                         </div>
                                         <div class="licence-entry">
-                                            <dt>XLD (X Lossless Decoder)</dt>
-                                            <dd><span class="licence-badge licence-badge--proprietary">Freeware</span> tmkk</dd>
-                                        </div>
-                                        <div class="licence-entry">
-                                            <dt>FFmpeg / FFprobe</dt>
-                                            <dd><span class="licence-badge">LGPL-2.1+</span> The FFmpeg Project</dd>
-                                        </div>
-                                        <div class="licence-entry">
                                             <dt>libusb</dt>
                                             <dd><span class="licence-badge">LGPL-2.1+</span> libusb contributors</dd>
                                         </div>
                                         <div class="licence-entry">
                                             <dt>libkalam (MTP)</dt>
-                                            <dd><span class="licence-badge">MIT</span> UX Music Project</dd>
+                                            <dd><span class="licence-badge">BSD-3-Clause</span> Copyright (c) 2012 Google Inc.（github.com/ganeshrvel/go-mtpfs 由来）</dd>
+                                        </div>
+                                    </dl>
+                                </section>
+                                <section class="licence-section">
+                                    <h5>外部プログラム（同梱せず、実行時に利用）</h5>
+                                    <dl class="licence-list">
+                                        <div class="licence-entry">
+                                            <dt>FFmpeg / FFprobe</dt>
+                                            <dd><span class="licence-badge licence-badge--proprietary">ユーザー環境のインストール</span> PATH 上の実行ファイルを利用（同梱なし。ライセンスはユーザー自身のビルドに依存）</dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>XLD (X Lossless Decoder)</dt>
+                                            <dd><span class="licence-badge licence-badge--proprietary">ユーザー環境のインストール</span> tmkk（同梱なし。/Applications/XLD.app を呼び出すのみ）</dd>
                                         </div>
                                     </dl>
                                 </section>
@@ -575,16 +589,40 @@
                                     <h5>Goライブラリ</h5>
                                     <dl class="licence-list">
                                         <div class="licence-entry">
+                                            <dt>github.com/bitly/go-simplejson</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/cenkalti/backoff</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
                                             <dt>github.com/dhowden/tag</dt>
                                             <dd><span class="licence-badge">BSD-2-Clause</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/dlclark/regexp2</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/dop251/goja</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
                                         </div>
                                         <div class="licence-entry">
                                             <dt>github.com/ebitengine/purego</dt>
                                             <dd><span class="licence-badge">Apache-2.0</span></dd>
                                         </div>
                                         <div class="licence-entry">
-                                            <dt>github.com/go-audio/audio · riff · wav</dt>
-                                            <dd><span class="licence-badge">MIT</span></dd>
+                                            <dt>github.com/go-audio/audio · github.com/go-audio/riff · github.com/go-audio/wav</dt>
+                                            <dd><span class="licence-badge">Apache-2.0</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/go-sourcemap/sourcemap</dt>
+                                            <dd><span class="licence-badge">BSD-2-Clause</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/google/pprof</dt>
+                                            <dd><span class="licence-badge">Apache-2.0</span></dd>
                                         </div>
                                         <div class="licence-entry">
                                             <dt>github.com/google/uuid</dt>
@@ -595,23 +633,59 @@
                                             <dd><span class="licence-badge">MIT</span></dd>
                                         </div>
                                         <div class="licence-entry">
+                                            <dt>github.com/grandcat/zeroconf</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
                                             <dt>github.com/hajimehoshi/go-mp3</dt>
                                             <dd><span class="licence-badge">Apache-2.0</span></dd>
                                         </div>
                                         <div class="licence-entry">
-                                            <dt>github.com/hugolgst/rich-go</dt>
-                                            <dd><span class="licence-badge">MIT</span></dd>
+                                            <dt>github.com/icza/bitio</dt>
+                                            <dd><span class="licence-badge">Apache-2.0</span></dd>
                                         </div>
                                         <div class="licence-entry">
                                             <dt>github.com/kkdai/youtube/v2</dt>
                                             <dd><span class="licence-badge">MIT</span></dd>
                                         </div>
                                         <div class="licence-entry">
+                                            <dt>github.com/leaanthony/go-ansi-parser</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/leaanthony/slicer</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/leaanthony/u</dt>
+                                            <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
                                             <dt>github.com/mewkiz/flac</dt>
-                                            <dd><span class="licence-badge">0BSD</span></dd>
+                                            <dd><span class="licence-badge">Unlicense</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/mewkiz/pkg</dt>
+                                            <dd><span class="licence-badge">Unlicense</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/mewpkg/term</dt>
+                                            <dd><span class="licence-badge">Unlicense</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/miekg/dns</dt>
+                                            <dd><span class="licence-badge">BSD-3-Clause</span></dd>
                                         </div>
                                         <div class="licence-entry">
                                             <dt>github.com/mjibson/go-dsp</dt>
+                                            <dd><span class="licence-badge">ISC</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/pkg/errors</dt>
+                                            <dd><span class="licence-badge">BSD-2-Clause</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>github.com/rivo/uniseg</dt>
                                             <dd><span class="licence-badge">MIT</span></dd>
                                         </div>
                                         <div class="licence-entry">
@@ -621,6 +695,18 @@
                                         <div class="licence-entry">
                                             <dt>github.com/wailsapp/wails/v2</dt>
                                             <dd><span class="licence-badge">MIT</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>golang.org/x/crypto</dt>
+                                            <dd><span class="licence-badge">BSD-3-Clause</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>golang.org/x/net</dt>
+                                            <dd><span class="licence-badge">BSD-3-Clause</span></dd>
+                                        </div>
+                                        <div class="licence-entry">
+                                            <dt>golang.org/x/sys</dt>
+                                            <dd><span class="licence-badge">BSD-3-Clause</span></dd>
                                         </div>
                                         <div class="licence-entry">
                                             <dt>golang.org/x/text</dt>


### PR DESCRIPTION
設定ダイアログ最下部のライセンス表示（`<details class="licence-details">`）に、事実と異なる記載と約20件の記載漏れがあったため修正します。

## 修正した誤り

| 項目 | 修正前 | 修正後 |
|---|---|---|
| libkalam (MTP) | MIT / UX Music Project | **BSD-3-Clause** / Copyright (c) 2012 Google Inc.（ganeshrvel/go-mtpfs 由来） |
| go-audio/audio・riff・wav | MIT | **Apache-2.0** |
| mewkiz/flac | 0BSD | **Unlicense** |
| mjibson/go-dsp | MIT | **ISC** |
| hugolgst/rich-go | MIT | **削除**（go.mod に無く、リンクもされていない） |

libkalam は他者の著作物（Google 名義の BSD ライセンスコード）を自プロジェクトの MIT 成果物として表示していました。BSD 3条項は著作権表示の保持を要求するため、帰属を正しました。

## 同梱していないものの分離

FFmpeg / FFprobe と XLD が「バンドルバイナリ」に含まれていましたが、いずれも同梱しておらずユーザー環境のものを利用します（FFmpeg は `locateFfmpeg()` が PATH から解決、XLD は `/Applications/XLD.app` を呼ぶ 204 バイトのシェルスクリプト）。「外部プログラム（同梱せず、実行時に利用）」として分離しました。

FFmpeg の `LGPL-2.1+` 表記も削除しています。ユーザーのビルド構成に依存し（Homebrew 版は `--enable-gpl`）、こちらが断定できる情報ではないためです。

## 追加

実際にバイナリへリンクされる Go モジュール 33 件のうち未記載だった約20件を追加。全ライセンスはモジュールキャッシュ内の LICENSE ファイルから直接確認しました。あわせてアプリ自身が GPL-3.0 であることを明示しています。

## ドリフト防止テスト

`main_licence_list_test.go` を追加。`go list -deps` でリンク済みモジュール集合を取得し、その全てが `index.html` に記載されていることを検証します。今後依存を追加して表示更新を忘れると `make test-go` が落ちます。

逆方向（記載されているものが全てリンクされている）は検証しません。同梱ネイティブバイナリや他プラットフォーム固有モジュールの記載が正当に含まれるためです。

エントリを1件削除して実際に赤くなることを確認済み。`npm run typecheck` / renderer 339件も通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)