### PR TITLE
fix: 中継エンジンの世代なきティアダウン競合を修正（CI固有失敗の真因）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,12 +85,6 @@ jobs:
       - name: go test (-shuffle=on)
         run: go test -count=1 -shuffle=on ${{ steps.pkgs.outputs.list }}
 
-      # relay_ci_research/ の一時診断ステップ: server パッケージの中継テスト
-      # だけを繰り返し・単独実行し、CI 固有の失敗がクロステスト干渉か
-      # テスト単体の問題かを切り分ける。調査完了後に削除すること。
-      - name: "[TEMP] go test relay isolation (-race, -count=5)"
-        run: go test -race -count=5 -v -run '^TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes$' ./server/
-
   # ---------------------------------------------------------------------------
   # Go: Windows 専用コードのビルドゲート
   # ---------------------------------------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,12 @@ jobs:
       - name: go test (-shuffle=on)
         run: go test -count=1 -shuffle=on ${{ steps.pkgs.outputs.list }}
 
+      # relay_ci_research/ の一時診断ステップ: server パッケージの中継テスト
+      # だけを繰り返し・単独実行し、CI 固有の失敗がクロステスト干渉か
+      # テスト単体の問題かを切り分ける。調査完了後に削除すること。
+      - name: "[TEMP] go test relay isolation (-race, -count=5)"
+        run: go test -race -count=5 -v -run '^TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes$' ./server/
+
   # ---------------------------------------------------------------------------
   # Go: Windows 専用コードのビルドゲート
   # ---------------------------------------------------------------------------

--- a/relay_ci_research/notes/INDEX.md
+++ b/relay_ci_research/notes/INDEX.md
@@ -1,0 +1,5 @@
+# relay_ci_research ノート索引
+
+新しいものが上。
+
+- [stale-cmd-wait-teardown.md](stale-cmd-wait-teardown.md) — `TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes` が GitHub Actions の ubuntu-latest ランナーでのみ「両クライアント0バイト」で失敗していた件の原因調査。CI に `-race` で計測用の診断フックを仕込んだところ、直前のテスト（Single client）の ffmpeg stderr 読み取りゴルーチンが次テストの `Start()` 後もまだ生きていることを示すデータレースを検出。`relayEngine` の Start/Stop に世代（generation）の概念が無く、古いセッションの「ffmpeg 終了を待って Stop() する」ゴルーチンが新しいセッションを巻き込んで破棄しうる再入可能性バグと特定。世代カウンタで修正し、CI で3回連続グリーンを確認。仮説採択、GITHUB_ACTIONS スキップは解除済み。

--- a/relay_ci_research/notes/stale-cmd-wait-teardown.md
+++ b/relay_ci_research/notes/stale-cmd-wait-teardown.md
@@ -245,3 +245,120 @@ installed version is 5.10.0` で毎回落ちているが、これは `main` ブ�
 （`server/app_remote_relay_test.go`）を残した。これは実 ffmpeg プロセス
 を起動せず `stopIfCurrent` を直接駆動するホワイトボックステストであり、
 今後 `relayEngine` のライフサイクルを変更する際の安全網になる。
+
+## 追記: 世代ガードそのものが非原子だった（レビュー指摘）
+
+上記の `stopIfCurrent` 初版は次のように書かれていた:
+
+```go
+func (e *relayEngine) stopIfCurrent(gen int) {
+	e.mu.Lock()
+	if gen != e.generation {
+		e.mu.Unlock()
+		return
+	}
+	e.mu.Unlock()   // ここで一旦ロック解放
+	e.Stop()        // Stop() が再度ロックを取る。その間に generation が変わりうる
+}
+```
+
+「世代が一致するか確認する」区間と「実際に teardown する」区間が **別々
+のクリティカルセクション**になっており、両者の間にロックが解放される
+隙間があった。この隙間だけを見れば以下のインターリーブが理論上可能:
+
+1. `stopIfCurrent(gen=5)` が `e.generation == 5` を確認してアンロック。
+2. その間に別ゴルーチンで `Start()` が走る:
+   冒頭の `e.Stop()` で世代が 6 に、続く `Start()` 自身の処理で世代が 7
+   になり、新しいセッションが `active = true` になる。
+3. `stopIfCurrent` が再開して `e.Stop()` を呼び、世代 7（＝直前に始まった
+   ばかりの新しいセッション）を破棄してしまう。
+
+これは今回修正したはずの「古いセッションが新しいセッションを巻き込んで
+破棄する」バグそのものであり、単に発生しうる窓（ウィンドウ）が「ffmpeg
+プロセスの終了・パイプ EOF にかかる秒単位の時間」から「ロック解放から
+再取得までの数命令」へと桁違いに狭まっただけだった。世代ガードを導入した
+目的は「stale teardown をほぼ起きなくする」ことではなく「原理的に起こり
+得なくする」ことだったため、この残存ウィンドウは見過ごせないレビュー
+指摘として扱った。
+
+### 修正
+
+チェックと teardown を同一のクリティカルセクションにするため、
+ロックを保持したまま teardown 本体を呼べるように `teardownLocked` を
+切り出した:
+
+```go
+func (e *relayEngine) Stop() {
+	e.mu.Lock()
+	e.teardownLocked()
+}
+
+// teardownLocked は e.mu を保持した状態で呼ばれる必要があり、内部で
+// アンロックする（何もアクティブでなければ即座に、そうでなければ
+// teardown 対象の状態をキャプチャした直後に、ブロッキングする
+// cancel()/close() の前で）。
+func (e *relayEngine) teardownLocked() {
+	e.generation++
+	if !e.active {
+		e.mu.Unlock()
+		return
+	}
+	// ...以降、既存の cancel/subs キャプチャ → e.mu.Unlock() → cancel() → close() ...
+}
+
+func (e *relayEngine) stopIfCurrent(gen int) {
+	e.mu.Lock()
+	if gen != e.generation {
+		e.mu.Unlock()
+		return
+	}
+	e.teardownLocked()   // ロックを保持したまま teardown。隙間なし
+}
+```
+
+`Start()` は `e.mu` を保持したまま世代をインクリメントするため、
+「世代の比較」から「実際のインクリメント（teardown 側）」までロックを
+保持し続けることで、この窓を完全に閉じられる。
+
+`teardownLocked` という名前は「ロックを握ったまま呼ぶ」契約を示す一方で、
+関数自身は内部でアンロックして返る（呼び出し元はロックの解放を意識しなくて
+よい）ため、この非対称な契約をコメントで明示した。
+
+### この窓をテストで直接踏ませることはしなかった
+
+チェックと teardown の間に意図的にフックを挟んで狙って踏ませることは、
+バグそのものより有害（本番コードに「テストのためだけに存在する隙間」を
+作ることになる）と判断し、行っていない。既存の
+`TestRelayEngine_StaleGenerationStopIsNoOp` は「古い世代からの
+`stopIfCurrent` 呼び出しが現行セッションを壊さない」という振る舞いを
+そのままカバーしており、今回の変更はその振る舞いを変えない構造的な
+窓の除去（チェックと teardown の単一クリティカルセクション化）である
+ため、既存テストのままで十分と判断した。
+
+### `Subscribe` / `unsubscribe` / `State` の同種パターンの点検
+
+同じ「ロック下で読んで、解放してから、読んだ内容が依然として真である
+前提で行動する」パターンが他に無いか確認した:
+
+- `Subscribe`・`unsubscribe`: どちらも `e.mu.Lock(); defer e.mu.Unlock()`
+  の単一クリティカルセクション内で読み取りと書き込みの両方を完結して
+  おり、ロックを跨いだ「読んでから行動する」区間は無い。**問題なし。**
+- `State()`: 単純なスナップショット取得（`active/title/thumbnail` を
+  ロック下でコピーして返すだけ）であり、それ自体に read-modify-write は
+  無い。**関数単体としては問題なし。**
+  ただし呼び出し側の `remoteRelayHandler`（同ファイル）に
+  `State()` → （ロック解放）→ `Subscribe()` という2段の呼び出しがあり、
+  その間に `Stop()` が挟まると「`State()` 時点では active だったが
+  `Subscribe()` 時点ではすでに非アクティブ」という状態で購読が成立し
+  うる。この場合、新しく作られた（Stop 後の空の）`subs` マップに購読者
+  が追加されるだけで、以後 `broadcast` が呼ばれることも無く、また
+  `Stop()` 済みなのでその購読チャンネルが `close` されることも無い
+  （次に `Start()`→`Stop()` が起きるまで）。実害は
+  「クライアントが `r.Context().Done()`（切断）まで無音のまま待たされる」
+  程度で、他セッションを破壊するような重大度ではないが、`State()` と
+  `Subscribe()` の非原子性という意味では確かに同種のパターンである。
+  今回の世代ガード修正のスコープ外（別のハンドラ層の話であり、
+  `relayEngine` 自体の再入可能性バグではない）と判断し、**未修正のまま
+  記録に残す**。将来 `remoteRelayHandler` を触る際は、
+  `Subscribe()` 自体に「アクティブでなければ即座に閉じたチャンネルを
+  返す」といった原子的な確認を追加する形で解消できる。

--- a/relay_ci_research/notes/stale-cmd-wait-teardown.md
+++ b/relay_ci_research/notes/stale-cmd-wait-teardown.md
@@ -1,0 +1,247 @@
+# relayEngine の再入可能性バグと GitHub Actions 固有の中継テスト失敗
+
+## 目的 / 仮説
+
+`server/app_remote_relay_test.go` の
+`TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes` が、GitHub
+Actions の `ubuntu-latest` ランナー上でのみ「2クライアントとも0バイト」で
+再現性よく失敗し、`GITHUB_ACTIONS` 環境変数によるスキップで握りつぶされて
+いた。同じ Linux（linux/amd64、Docker、`-race`、CPU 制限あり/なし、
+`count=20`）ではローカルで一度も再現しなかった。単一クライアント版
+（`TestRemoteRelayEngine_SingleClientReceivesADTSBytes`）は同じ CI で安定
+して通っていたため、ffmpeg パイプライン自体は機能しているはずで、「2クラ
+イアント同時購読」または「CI 環境固有の何か」に絞られていた。
+
+出発仮説（コード分析による事前提示、本調査で検証）:
+
+> `relayEngine.Start()` が spawn する「`cmd.Wait()` の完了を待って
+> `e.Stop()` する」ゴルーチンは、自分がどのセッションに属するかを区別
+> できていない。`Stop()` もその等ゴルーチンの完了を待たない。直前の
+> テストの ffmpeg プロセスの終了・パイプ EOF が CI の混雑したランナー
+> で遅延し、次のテストの `Start()` より後に完了すると、古いセッション
+> の `Stop()` が新しいセッションの購読者を巻き込んで破棄してしまう
+> （generation なしの非同期 Stop() レース）。
+
+反証条件: 対象テストを `-run` で単独・繰り返し実行して CI 上でも失敗する
+なら、クロステスト干渉ではなくテスト単体の問題。
+
+## 環境
+
+- リポジトリ: `HariBote1110/UX-Music`、調査ブランチ `relay-ci-diagnosis`
+  （起点 `origin/main`）
+- CI: GitHub Actions、`test.yml` の `go test (linux)` ジョブ、
+  `runs-on: ubuntu-latest`
+  - Go: 1.25.5（`/opt/hostedtoolcache/go/1.25.5/x64`、CI ログのスタック
+    トレースパスより）
+  - ffmpeg: `ffmpeg version 6.1.1-3ubuntu5`（apt でインストール、CI ログの
+    `-version` 出力より）
+  - 対象パッケージ: `ux-music-sidecar/server`
+  - CI は同一パッケージ集合に対して `go test -race` と
+    `go test -shuffle=on` の2ステップを実行する
+- ローカル比較環境: macOS（darwin/arm64）、ffmpeg 8.0.1（Homebrew）、
+  Go はローカル `go.mod` 指定バージョン
+
+## 手順
+
+1. `server/app_remote_relay_test.go:220` の `GITHUB_ACTIONS` スキップを
+   一時的に外す。
+2. `server/app_remote_relay.go` の `relayEngine` に診断フック
+   `debugf func(format string, args ...interface{})`（テストのみ
+   `t.Logf` を注入、本番は nil）を追加し、以下を計測できるようにする:
+   - ffmpeg の解決パスと `cmd.Start()` の成否
+   - ffmpeg stderr の全行（従来 `cmd.Stderr` は未設定＝`os.DevNull` に
+     破棄されており、誰も見ていなかった）
+   - `pumpPCM` が書き込んだ PCM バイト数の累計
+   - `pumpADTS` が読み取った ADTS バイト数の累計・最初のチャンク到着
+   - `broadcast` 呼び出しごとの購読者数・送信数・`default:` での drop 数
+   - `Subscribe` 呼び出しのタイミング
+3. `relay-ci-diagnosis` ブランチに push し、
+   `gh run list --branch relay-ci-diagnosis` / `gh run view <id> --log`
+   で実際の CI 出力を確認。
+4. 1回目の push で `-race` ステップがデータレースを検出して FAIL。
+   その内容から核心的な手がかりを得た（下記結果参照）。
+5. `relayEngine` に世代カウンタ（`generation`）を導入し、
+   `cmd.Wait()` 完了時の teardown を `stopIfCurrent(gen)` 経由にして
+   「自分の世代が現行世代と一致する場合のみ」実行するよう修正
+   （`server/app_remote_relay.go`）。
+6. 診断フック用に `debugMu sync.RWMutex` を追加し、`e.mu` を握ったまま
+   `logf` を呼ぶ既存コード（`broadcast`・`Subscribe`）とのデッドロックを
+   避けつつフィールドアクセスを race-safe にした。
+7. 世代ガードの単体テスト `TestRelayEngine_StaleGenerationStopIsNoOp` を
+   `server/app_remote_relay_test.go` に追加（実プロセスに依存しない
+   ホワイトボックステスト。`stopIfCurrent` を直接呼び、古い世代の呼び出し
+   が現行セッションを破棄しないことを検証）。
+8. 一時的な CI ステップ
+   `go test -race -count=5 -run '^TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes$' ./server/`
+   を `test.yml` に追加し、クロステスト干渉かどうかの切り分けを高速化。
+9. push → CI 確認を計3回実施（うち1回は `gh workflow run` による手動
+   再実行）。3回とも `go test (linux)` ジョブ（`-race` / `-shuffle=on` /
+   一時的な単独5回実行）が全てグリーン。
+10. 診断用の一時的な計測コード（`debugf`／`pumpStderr`／各種
+    `logf` 呼び出し）と一時 CI ステップを削除し、世代カウンタ本体の
+    修正のみを残す形に整理。整理後も `go build`・`go vet`・ローカル
+    `-race` テストがグリーンであることを確認。
+
+## 結果
+
+### 1回目の push（診断計測のみ、修正前）で判明したこと
+
+`go test -race` ステップが、狙っていた「0バイト」ではなく **データレース
+検出**で FAIL した:
+
+```
+WARNING: DATA RACE
+Write at 0x000001b2cb90 by goroutine 220:
+  ux-music-sidecar/server.TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes()
+      .../app_remote_relay_test.go:226   (remoteRelay.debugf = t.Logf)
+
+Previous read at 0x000001b2cb90 by goroutine 208:
+  ux-music-sidecar/server.(*relayEngine).logf()
+      .../app_remote_relay.go:79
+  ux-music-sidecar/server.(*relayEngine).pumpStderr()
+      .../app_remote_relay.go:185
+  ux-music-sidecar/server.(*relayEngine).Start.gowrap1()
+      .../app_remote_relay.go:165
+
+Goroutine 208 (finished) created at:
+  ux-music-sidecar/server.(*relayEngine).Start()
+      .../app_remote_relay.go:165
+  ux-music-sidecar/server.TestRemoteRelayEngine_SingleClientReceivesADTSBytes()
+      .../app_remote_relay_test.go:150
+```
+
+これは **直前の `TestRemoteRelayEngine_SingleClientReceivesADTSBytes` が
+起動した ffmpeg セッションの stderr 読み取りゴルーチンが、次のテスト
+（Multi client）の `Start()` 呼び出し後もまだ生きていた**ことを示す直接
+証拠である。`t.Cleanup(remoteRelay.Stop)` は `cancel()` を呼ぶだけで、
+その後にプロセスが実際に終了し、パイプが EOF になり、ゴルーチンが
+`return` するまでは待たない。CI の共有ランナーではこの「後片付けの尻尾」
+が数ミリ秒〜十数ミリ秒残ることがあり、次のテストの初期化と時間的に
+重なりうる。
+
+これは事前提示された仮説（generation なしの非同期 `Stop()` レース）が
+主張する機構——「古いセッションのゴルーチンが新しいセッションの状態を
+いじる」——を、レースディテクタが客観的に裏付けた形になる。ただし今回
+実際にレースを起こしたのは元コードのフィールドではなく、調査のために
+新規追加した `debugf` フィールドだった点には注意（下記「棄却した/確定
+しなかった点」参照）。
+
+### 2回目の push（世代カウンタ導入後）
+
+同じ CI ジョブ（Go 1.25.5 / ffmpeg 6.1.1-3ubuntu5 / ubuntu-latest）で:
+
+| ステップ | 結果 |
+|---|---|
+| `go test (-race)`（全パッケージ） | PASS（`ux-music-sidecar/server ok 3.711s`） |
+| `go test (-shuffle=on)`（全パッケージ） | PASS（`ux-music-sidecar/server ok 2.864s`） |
+| `[TEMP] go test relay isolation (-race, -count=5)` | PASS × 5回連続 |
+
+### 3回目・4回目（`gh workflow run` による手動再実行 × 2）
+
+いずれも `go test (linux)` ジョブは全ステップ PASS。合計で
+「`go test (linux)` ジョブがグリーン」を3回連続で観測。
+
+（参考: 同じ実行で `swift test (lyrics-sync CLI)` が
+`package 'lyrics-sync' is using Swift tools version 6.0.0 but the
+installed version is 5.10.0` で毎回落ちているが、これは `main` ブランチ
+でも既知の別件インフラ問題であり、本調査とは無関係。`gh run list
+--branch main` で直近5回のワークフロー実行が同じ理由で failure に
+なっていることを確認済み。）
+
+## 結論
+
+- **仮説は採択**: `relayEngine` には Start/Stop の再入可能性バグが実在
+  した。`Start()` の末尾が spawn する「`cmd.Wait()` を待って `e.Stop()`
+  する」ゴルーチンは、自分がどのセッションに属するかを区別しておらず、
+  `Stop()` 側もそれらのゴルーチンの完了を待たない。ffmpeg プロセスの
+  終了・パイプ EOF のタイミングが実行環境（特に CI の混雑した共有
+  ランナー）に依存するため、古いセッションの後片付けが新しいセッション
+  の開始後にずれ込むことがあり、その場合は新しいセッションの購読者が
+  巻き込まれて破棄されうる。
+- 修正: `relayEngine` に `generation int` を追加。`Start()` は自分の
+  世代番号 `gen` を記録し、`cmd.Wait()` ゴルーチンは
+  `stopIfCurrent(gen)` を呼ぶ。これは `gen` が現行世代と一致する場合に
+  のみ実際の `Stop()` を実行する。明示的な `Stop()` 呼び出し
+  （テストの `t.Cleanup`、`Start()` 冒頭の呼び出し、実運用での曲切り替え
+  時の再起動）は常に世代をインクリメントするため、古い世代からの遅延
+  `stopIfCurrent` は確実に no-op になる。
+- これは**テストだけの問題ではなく本番コードのバグ**でもある:
+  `NotifyYouTubePlaybackState` は曲が変わるたびに `remoteRelay.Start()`
+  を呼び直す（`Start()` 冒頭で前のセッションを `Stop()` する設計）。
+  ユーザーが素早く曲を切り替えた場合、切り替え前の ffmpeg の
+  `cmd.Wait()` が新しいセッション開始後に完了すると、生きている LAN
+  中継が無音で落ちる可能性があった。今回の修正はテストの CI 固有失敗と
+  同時にこの本番経路のバグも塞ぐ。
+- `GITHUB_ACTIONS` によるスキップは解除した
+  （`server/app_remote_relay_test.go`）。CI で3回連続グリーンを確認
+  済み。
+
+### 棄却した仮説 / 確定しなかった点
+
+- **バッファエイリアシング（fan-out での使い回し）**: 事前調査で棄却
+  済み（`pumpADTS` はチャンクごとに新しい `[]byte` を allocate してから
+  `copy` しており、購読者間で共有していない）。本調査でも
+  `broadcast`/`pumpADTS` のロジックを再確認したが、この仮説を再検証
+  する新たな証拠は無く、棄却のまま。
+- **Subscribe/HTTP ハンドシェイクの遅延そのもの**: 既存コメント
+  （テスト冒頭）が示す「生配信ウィンドウ 300ms 版では購読が間に合わない」
+  問題は、生配信ウィンドウを5秒に広げる対応で別途解消済みとされており、
+  本調査で新たに反証・追認する材料は得られなかった（＝今回の主因では
+  ないという既存の判断を維持）。
+- **`-shuffle=on` 固有の順序依存バグ**: 修正前の状態で
+  `-shuffle=on` ステップ単体が独立に失敗するかどうかは、1回目の push が
+  `-race` ステップで先に FAIL したため（`concurrency` 設定と
+  ステップの直列実行により、`-race` が落ちた時点でジョブ全体が
+  `##[error]Process completed with exit code 1` となり後続ステップは
+  スキップされずそのまま実行されるが、今回はログ上 `-shuffle=on` 自体は
+  評価されなかった）、**未検証**。ただし修正後は `-race` /
+  `-shuffle=on` とも3回連続グリーンであり、実用上は解消したと判断した。
+  「`-shuffle=on` だけが失敗するのか `-race` だけなのか」という当初の
+  切り分け観点については、**今回確認できたのは `-race` ステップで
+  データレースとして症状が可視化されたという事実のみ**であり、
+  `-shuffle=on` 単体が独立に「0バイト」症状を起こすかどうかは未確定の
+  まま残る（世代カウンタ修正でどちらのステップも通るようになったため、
+  これ以上の切り分けは行っていない）。
+- **ffmpeg のバージョン差（CI: 6.1.1-3ubuntu5 / ローカル: 8.0.1）が
+  原因**という仮説は、今回は積極的に検証していない。ただし
+  `TestRemoteRelayEngine_SingleClientReceivesADTSBytes` は同じ CI 環境
+  （同じ ffmpeg 6.1.1-3ubuntu5）で一貫して成功しており、ffmpeg
+  バージョン差そのものが単独の原因ではないと考えられる（再入可能性
+  バグの発現しやすさに間接的に影響していた可能性は否定できないが、
+  検証はしていない）。
+
+## 次の一手 / 未検証事項
+
+- 今回の3回の CI グリーンは「修正が有効であることの強い状況証拠」では
+  あるが、元の失敗自体が確率的（レースコンディション）だったため、
+  「絶対に再発しない」ことの証明にはならない。継続的に CI で監視し、
+  再発した場合はこのノートを更新すること。
+- `-shuffle=on` ステップ単体が独立に問題を起こすかどうかの切り分けは
+  未完了（上記参照）。もし将来別の理由でこのテストが再び不安定になった
+  場合、`-race` と `-shuffle=on` を分けて調べる価値がある。
+- 診断のために追加した `debugf` フック・`pumpStderr`・各種バイト数計測は
+  **すべて削除した**（下記「計測コードの扱い」参照）。同種の調査が必要に
+  なった場合は、本ノートの「手順」を参照して同じ仕組みを再構築できる。
+
+## 計測コードの扱い
+
+診断用に追加した以下のコードは、調査完了後に**すべて削除**した（本番の
+中継ホットパスに常駐させる判断はしなかった）:
+
+- `relayEngine.debugf` / `debugMu` / `logf` / `setDebugf`
+- `relayEngine.pumpStderr`（ffmpeg stderr のパイプ取得・行ごとの中継）
+- `pumpPCM` / `pumpADTS` / `broadcast` 内のバイト数・購読者数ログ
+- `test.yml` の一時ステップ `[TEMP] go test relay isolation`
+
+理由: これらは `broadcast` のような 1 チャンクごとに呼ばれるホット
+パス上で毎回ロック＋関数呼び出しを行うものであり、本番で常時有効化する
+価値（＝実運用でこのクラスの再入可能性バグが再発したときの診断材料）
+より、恒常的なオーバーヘッドと「調査用コードが本番に残り続ける」こと
+自体のリスクの方が大きいと判断した。実際に効いた恒久的な修正は
+`relayEngine.generation` / `stopIfCurrent` の世代ガードのみであり、
+これは通常運用時のコストがロック内でのフィールド比較1回程度に収まる。
+
+回帰防止テストとして `TestRelayEngine_StaleGenerationStopIsNoOp`
+（`server/app_remote_relay_test.go`）を残した。これは実 ffmpeg プロセス
+を起動せず `stopIfCurrent` を直接駆動するホワイトボックステストであり、
+今後 `relayEngine` のライフサイクルを変更する際の安全網になる。

--- a/server/app_remote_relay.go
+++ b/server/app_remote_relay.go
@@ -166,14 +166,22 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 // Explicit callers (t.Cleanup(remoteRelay.Stop), Start()'s own leading
 // e.Stop()) go through Stop() directly and always tear down, bumping the
 // generation so any still-pending stopIfCurrent(oldGen) becomes a no-op.
+//
+// The generation check and the teardown are performed in the same critical
+// section (via teardownLocked) rather than as two separate lock/unlock
+// pairs: releasing the lock between "gen still matches" and "tear down"
+// would reopen — in a much narrower window, but not a closed one — exactly
+// the stale-teardown race this mechanism exists to prevent (Start() could
+// bump the generation and activate a new session in the gap). See
+// relay_ci_research/notes/stale-cmd-wait-teardown.md for why this matters
+// even though the window is only a few instructions wide.
 func (e *relayEngine) stopIfCurrent(gen int) {
 	e.mu.Lock()
 	if gen != e.generation {
 		e.mu.Unlock()
 		return
 	}
-	e.mu.Unlock()
-	e.Stop()
+	e.teardownLocked()
 }
 
 // pumpPCM reads interleaved float32 frames from source and writes them as
@@ -236,10 +244,22 @@ func (e *relayEngine) broadcast(chunk []byte) {
 // channel, ending their HTTP responses. Safe to call when nothing is active.
 func (e *relayEngine) Stop() {
 	e.mu.Lock()
-	// Bump unconditionally (even when nothing is active) so that any
-	// stopIfCurrent(gen) still in flight from a previous session's cmd.Wait()
-	// goroutine is guaranteed to see a mismatch and no-op, regardless of
-	// whether this Stop() call itself has anything to tear down.
+	e.teardownLocked()
+}
+
+// teardownLocked bumps the generation and, if a session is active, tears it
+// down: it must be called with e.mu already held, and it releases e.mu
+// itself (immediately if nothing is active; otherwise after capturing the
+// state to tear down, before the blocking cancel()/close() calls) rather
+// than leaving that to the caller. Callers must not touch e.mu again after
+// calling this.
+//
+// Bumping the generation happens before the active check, unconditionally,
+// so that any stopIfCurrent(gen) still in flight from a previous session's
+// cmd.Wait() goroutine is guaranteed to see a mismatch and no-op on its next
+// call, regardless of whether this particular call has anything to tear
+// down.
+func (e *relayEngine) teardownLocked() {
 	e.generation++
 	if !e.active {
 		e.mu.Unlock()

--- a/server/app_remote_relay.go
+++ b/server/app_remote_relay.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bufio"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -11,7 +10,6 @@ import (
 	"os/exec"
 	"strconv"
 	"sync"
-	"time"
 )
 
 // remoteRelayCapability is advertised in /v1/identity's capabilities list,
@@ -73,39 +71,6 @@ type relayEngine struct {
 	nextSubID  int
 	cancel     context.CancelFunc
 	ffmpegPath func() (string, error)
-
-	// debugMu guards debugf independently of mu: logf is called from within
-	// code that already holds mu (e.g. broadcast, Subscribe), so debugf
-	// cannot share that lock without deadlocking.
-	debugMu sync.RWMutex
-	// debugf is a diagnostic hook for the GitHub Actions-only flakiness
-	// investigation in relay_ci_research/notes/. nil in production (zero
-	// overhead beyond a lock/nil check); tests set it via setDebugf to route
-	// timestamped pipeline events (ffmpeg stderr, byte counts, subscriber
-	// counts) to t.Logf. See relay_ci_research/notes/INDEX.md.
-	debugf func(format string, args ...interface{})
-}
-
-// setDebugf installs (or, with nil, clears) the diagnostic hook. Safe for
-// concurrent use with logf from any goroutine.
-func (e *relayEngine) setDebugf(fn func(format string, args ...interface{})) {
-	e.debugMu.Lock()
-	e.debugf = fn
-	e.debugMu.Unlock()
-}
-
-// logf reports to debugf when set, prefixed with a monotonic-ish wall clock
-// timestamp so events from ffmpeg's stderr goroutine, pumpPCM, pumpADTS and
-// broadcast can be interleaved and ordered after the fact. No-op (a lock plus
-// nil check) when debugf is unset, i.e. always in production.
-func (e *relayEngine) logf(format string, args ...interface{}) {
-	e.debugMu.RLock()
-	fn := e.debugf
-	e.debugMu.RUnlock()
-	if fn == nil {
-		return
-	}
-	fn("[%s] "+format, append([]interface{}{time.Now().Format("15:04:05.000000")}, args...)...)
 }
 
 func newRelayEngine() *relayEngine {
@@ -128,10 +93,8 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 
 	ffmpegPath, err := e.ffmpegPath()
 	if err != nil {
-		e.logf("ffmpegPath() failed: %v", err)
 		return fmt.Errorf("ffmpeg not found: %w", err)
 	}
-	e.logf("resolved ffmpeg path: %s", ffmpegPath)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, ffmpegPath,
@@ -169,17 +132,10 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 		cancel()
 		return fmt.Errorf("ffmpeg stdout pipe: %w", err)
 	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		cancel()
-		return fmt.Errorf("ffmpeg stderr pipe: %w", err)
-	}
 	if err := cmd.Start(); err != nil {
-		e.logf("cmd.Start() failed: %v", err)
 		cancel()
 		return fmt.Errorf("ffmpeg start: %w", err)
 	}
-	e.logf("cmd.Start() succeeded, pid=%d", cmd.Process.Pid)
 
 	e.mu.Lock()
 	e.generation++
@@ -190,12 +146,10 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 	e.cancel = cancel
 	e.mu.Unlock()
 
-	go e.pumpStderr(stderr)
 	go e.pumpPCM(source, stdin)
 	go e.pumpADTS(stdout)
 	go func() {
-		waitErr := cmd.Wait()
-		e.logf("cmd.Wait() returned: %v", waitErr)
+		_ = cmd.Wait()
 		e.stopIfCurrent(gen)
 	}()
 
@@ -215,24 +169,11 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 func (e *relayEngine) stopIfCurrent(gen int) {
 	e.mu.Lock()
 	if gen != e.generation {
-		e.logf("stopIfCurrent: stale generation %d (current %d), skipping teardown", gen, e.generation)
 		e.mu.Unlock()
 		return
 	}
 	e.mu.Unlock()
 	e.Stop()
-}
-
-// pumpStderr relays ffmpeg's stderr line-by-line to the diagnostic hook. In
-// production (debugf nil) this still drains the pipe — required so ffmpeg
-// never blocks writing to a full, unread stderr pipe — but does no logging
-// work beyond the drain.
-func (e *relayEngine) pumpStderr(stderr io.ReadCloser) {
-	defer stderr.Close()
-	scanner := bufio.NewScanner(stderr)
-	for scanner.Scan() {
-		e.logf("ffmpeg stderr: %s", scanner.Text())
-	}
 }
 
 // pumpPCM reads interleaved float32 frames from source and writes them as
@@ -242,11 +183,9 @@ func (e *relayEngine) pumpPCM(source RelayPCMSource, stdin io.WriteCloser) {
 	defer stdin.Close()
 	samples := make([]float32, 4096)
 	bytes := make([]byte, len(samples)*4)
-	var totalPCMBytes int64
 	for {
 		n, ok := source.ReadPCM(samples)
 		if !ok {
-			e.logf("pumpPCM: source exhausted, totalPCMBytesWritten=%d", totalPCMBytes)
 			return
 		}
 		if n == 0 {
@@ -255,12 +194,9 @@ func (e *relayEngine) pumpPCM(source RelayPCMSource, stdin io.WriteCloser) {
 		for i := 0; i < n; i++ {
 			binary.LittleEndian.PutUint32(bytes[i*4:], math.Float32bits(samples[i]))
 		}
-		written := n * 4
-		if _, err := stdin.Write(bytes[:written]); err != nil {
-			e.logf("pumpPCM: stdin.Write failed after totalPCMBytesWritten=%d: %v", totalPCMBytes, err)
+		if _, err := stdin.Write(bytes[:n*4]); err != nil {
 			return
 		}
-		totalPCMBytes += int64(written)
 	}
 }
 
@@ -269,22 +205,14 @@ func (e *relayEngine) pumpPCM(source RelayPCMSource, stdin io.WriteCloser) {
 func (e *relayEngine) pumpADTS(stdout io.ReadCloser) {
 	defer stdout.Close()
 	buf := make([]byte, 4096)
-	var totalADTSBytes int64
-	firstChunkLogged := false
 	for {
 		n, err := stdout.Read(buf)
 		if n > 0 {
-			if !firstChunkLogged {
-				e.logf("pumpADTS: first chunk arrived, n=%d bytes", n)
-				firstChunkLogged = true
-			}
-			totalADTSBytes += int64(n)
 			chunk := make([]byte, n)
 			copy(chunk, buf[:n])
 			e.broadcast(chunk)
 		}
 		if err != nil {
-			e.logf("pumpADTS: stdout.Read ended, totalADTSBytesRead=%d, err=%v", totalADTSBytes, err)
 			return
 		}
 	}
@@ -296,17 +224,12 @@ func (e *relayEngine) pumpADTS(stdout io.ReadCloser) {
 func (e *relayEngine) broadcast(chunk []byte) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	subCount := len(e.subs)
-	sent, dropped := 0, 0
 	for _, sub := range e.subs {
 		select {
 		case sub.ch <- chunk:
-			sent++
 		default:
-			dropped++
 		}
 	}
-	e.logf("broadcast: chunkBytes=%d subscribers=%d sent=%d dropped=%d", len(chunk), subCount, sent, dropped)
 }
 
 // Stop tears down the active encode (if any) and closes every subscriber's
@@ -351,7 +274,6 @@ func (e *relayEngine) Subscribe() (chan []byte, func()) {
 	e.nextSubID++
 	ch := make(chan []byte, 32)
 	e.subs[id] = &relaySubscriber{ch: ch}
-	e.logf("Subscribe: id=%d totalSubscribers=%d", id, len(e.subs))
 	return ch, func() { e.unsubscribe(id) }
 }
 

--- a/server/app_remote_relay.go
+++ b/server/app_remote_relay.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os/exec"
 	"strconv"
 	"sync"
+	"time"
 )
 
 // remoteRelayCapability is advertised in /v1/identity's capabilities list,
@@ -60,6 +62,24 @@ type relayEngine struct {
 	nextSubID  int
 	cancel     context.CancelFunc
 	ffmpegPath func() (string, error)
+
+	// debugf is a diagnostic hook for the GitHub Actions-only flakiness
+	// investigation in relay_ci_research/notes/. nil in production (zero
+	// overhead beyond a nil check); tests set it to route timestamped
+	// pipeline events (ffmpeg stderr, byte counts, subscriber counts) to
+	// t.Logf. See relay_ci_research/notes/INDEX.md.
+	debugf func(format string, args ...interface{})
+}
+
+// logf reports to debugf when set, prefixed with a monotonic-ish wall clock
+// timestamp so events from ffmpeg's stderr goroutine, pumpPCM, pumpADTS and
+// broadcast can be interleaved and ordered after the fact. No-op (single nil
+// check) when debugf is unset, i.e. always in production.
+func (e *relayEngine) logf(format string, args ...interface{}) {
+	if e.debugf == nil {
+		return
+	}
+	e.debugf("[%s] "+format, append([]interface{}{time.Now().Format("15:04:05.000000")}, args...)...)
 }
 
 func newRelayEngine() *relayEngine {
@@ -82,8 +102,10 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 
 	ffmpegPath, err := e.ffmpegPath()
 	if err != nil {
+		e.logf("ffmpegPath() failed: %v", err)
 		return fmt.Errorf("ffmpeg not found: %w", err)
 	}
+	e.logf("resolved ffmpeg path: %s", ffmpegPath)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, ffmpegPath,
@@ -121,10 +143,17 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 		cancel()
 		return fmt.Errorf("ffmpeg stdout pipe: %w", err)
 	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return fmt.Errorf("ffmpeg stderr pipe: %w", err)
+	}
 	if err := cmd.Start(); err != nil {
+		e.logf("cmd.Start() failed: %v", err)
 		cancel()
 		return fmt.Errorf("ffmpeg start: %w", err)
 	}
+	e.logf("cmd.Start() succeeded, pid=%d", cmd.Process.Pid)
 
 	e.mu.Lock()
 	e.active = true
@@ -133,14 +162,28 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 	e.cancel = cancel
 	e.mu.Unlock()
 
+	go e.pumpStderr(stderr)
 	go e.pumpPCM(source, stdin)
 	go e.pumpADTS(stdout)
 	go func() {
-		_ = cmd.Wait()
+		waitErr := cmd.Wait()
+		e.logf("cmd.Wait() returned: %v", waitErr)
 		e.Stop()
 	}()
 
 	return nil
+}
+
+// pumpStderr relays ffmpeg's stderr line-by-line to the diagnostic hook. In
+// production (debugf nil) this still drains the pipe — required so ffmpeg
+// never blocks writing to a full, unread stderr pipe — but does no logging
+// work beyond the drain.
+func (e *relayEngine) pumpStderr(stderr io.ReadCloser) {
+	defer stderr.Close()
+	scanner := bufio.NewScanner(stderr)
+	for scanner.Scan() {
+		e.logf("ffmpeg stderr: %s", scanner.Text())
+	}
 }
 
 // pumpPCM reads interleaved float32 frames from source and writes them as
@@ -150,9 +193,11 @@ func (e *relayEngine) pumpPCM(source RelayPCMSource, stdin io.WriteCloser) {
 	defer stdin.Close()
 	samples := make([]float32, 4096)
 	bytes := make([]byte, len(samples)*4)
+	var totalPCMBytes int64
 	for {
 		n, ok := source.ReadPCM(samples)
 		if !ok {
+			e.logf("pumpPCM: source exhausted, totalPCMBytesWritten=%d", totalPCMBytes)
 			return
 		}
 		if n == 0 {
@@ -161,9 +206,12 @@ func (e *relayEngine) pumpPCM(source RelayPCMSource, stdin io.WriteCloser) {
 		for i := 0; i < n; i++ {
 			binary.LittleEndian.PutUint32(bytes[i*4:], math.Float32bits(samples[i]))
 		}
-		if _, err := stdin.Write(bytes[:n*4]); err != nil {
+		written := n * 4
+		if _, err := stdin.Write(bytes[:written]); err != nil {
+			e.logf("pumpPCM: stdin.Write failed after totalPCMBytesWritten=%d: %v", totalPCMBytes, err)
 			return
 		}
+		totalPCMBytes += int64(written)
 	}
 }
 
@@ -172,14 +220,22 @@ func (e *relayEngine) pumpPCM(source RelayPCMSource, stdin io.WriteCloser) {
 func (e *relayEngine) pumpADTS(stdout io.ReadCloser) {
 	defer stdout.Close()
 	buf := make([]byte, 4096)
+	var totalADTSBytes int64
+	firstChunkLogged := false
 	for {
 		n, err := stdout.Read(buf)
 		if n > 0 {
+			if !firstChunkLogged {
+				e.logf("pumpADTS: first chunk arrived, n=%d bytes", n)
+				firstChunkLogged = true
+			}
+			totalADTSBytes += int64(n)
 			chunk := make([]byte, n)
 			copy(chunk, buf[:n])
 			e.broadcast(chunk)
 		}
 		if err != nil {
+			e.logf("pumpADTS: stdout.Read ended, totalADTSBytesRead=%d, err=%v", totalADTSBytes, err)
 			return
 		}
 	}
@@ -191,12 +247,17 @@ func (e *relayEngine) pumpADTS(stdout io.ReadCloser) {
 func (e *relayEngine) broadcast(chunk []byte) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	subCount := len(e.subs)
+	sent, dropped := 0, 0
 	for _, sub := range e.subs {
 		select {
 		case sub.ch <- chunk:
+			sent++
 		default:
+			dropped++
 		}
 	}
+	e.logf("broadcast: chunkBytes=%d subscribers=%d sent=%d dropped=%d", len(chunk), subCount, sent, dropped)
 }
 
 // Stop tears down the active encode (if any) and closes every subscriber's
@@ -236,6 +297,7 @@ func (e *relayEngine) Subscribe() (chan []byte, func()) {
 	e.nextSubID++
 	ch := make(chan []byte, 32)
 	e.subs[id] = &relaySubscriber{ch: ch}
+	e.logf("Subscribe: id=%d totalSubscribers=%d", id, len(e.subs))
 	return ch, func() { e.unsubscribe(id) }
 }
 

--- a/server/app_remote_relay.go
+++ b/server/app_remote_relay.go
@@ -54,7 +54,18 @@ type relaySubscriber struct {
 // a time (GUI mode plays one YouTube video at a time, per the plan's
 // "broadcast" model — no per-client video/relay).
 type relayEngine struct {
-	mu         sync.Mutex
+	mu sync.Mutex
+	// generation counts every Start()/Stop() transition. Each Start() records
+	// the generation it owns; the goroutine that calls cmd.Wait() for that
+	// session's ffmpeg process only tears the engine down if its generation
+	// is still current (see stopIfCurrent). This guards against a stale
+	// session's teardown racing a newer one: Stop() does not (and, given
+	// ffmpeg's process-exit latency, realistically cannot) wait for the
+	// previous session's goroutines to fully exit before Start() launches the
+	// next session, so without this guard a slow-to-exit previous ffmpeg
+	// process can tear down a session that already replaced it. See
+	// relay_ci_research/notes/ for the CI evidence that motivated this.
+	generation int
 	active     bool
 	title      string
 	thumbnail  string
@@ -63,23 +74,38 @@ type relayEngine struct {
 	cancel     context.CancelFunc
 	ffmpegPath func() (string, error)
 
+	// debugMu guards debugf independently of mu: logf is called from within
+	// code that already holds mu (e.g. broadcast, Subscribe), so debugf
+	// cannot share that lock without deadlocking.
+	debugMu sync.RWMutex
 	// debugf is a diagnostic hook for the GitHub Actions-only flakiness
 	// investigation in relay_ci_research/notes/. nil in production (zero
-	// overhead beyond a nil check); tests set it to route timestamped
-	// pipeline events (ffmpeg stderr, byte counts, subscriber counts) to
-	// t.Logf. See relay_ci_research/notes/INDEX.md.
+	// overhead beyond a lock/nil check); tests set it via setDebugf to route
+	// timestamped pipeline events (ffmpeg stderr, byte counts, subscriber
+	// counts) to t.Logf. See relay_ci_research/notes/INDEX.md.
 	debugf func(format string, args ...interface{})
+}
+
+// setDebugf installs (or, with nil, clears) the diagnostic hook. Safe for
+// concurrent use with logf from any goroutine.
+func (e *relayEngine) setDebugf(fn func(format string, args ...interface{})) {
+	e.debugMu.Lock()
+	e.debugf = fn
+	e.debugMu.Unlock()
 }
 
 // logf reports to debugf when set, prefixed with a monotonic-ish wall clock
 // timestamp so events from ffmpeg's stderr goroutine, pumpPCM, pumpADTS and
-// broadcast can be interleaved and ordered after the fact. No-op (single nil
-// check) when debugf is unset, i.e. always in production.
+// broadcast can be interleaved and ordered after the fact. No-op (a lock plus
+// nil check) when debugf is unset, i.e. always in production.
 func (e *relayEngine) logf(format string, args ...interface{}) {
-	if e.debugf == nil {
+	e.debugMu.RLock()
+	fn := e.debugf
+	e.debugMu.RUnlock()
+	if fn == nil {
 		return
 	}
-	e.debugf("[%s] "+format, append([]interface{}{time.Now().Format("15:04:05.000000")}, args...)...)
+	fn("[%s] "+format, append([]interface{}{time.Now().Format("15:04:05.000000")}, args...)...)
 }
 
 func newRelayEngine() *relayEngine {
@@ -156,6 +182,8 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 	e.logf("cmd.Start() succeeded, pid=%d", cmd.Process.Pid)
 
 	e.mu.Lock()
+	e.generation++
+	gen := e.generation
 	e.active = true
 	e.title = title
 	e.thumbnail = thumbnail
@@ -168,10 +196,31 @@ func (e *relayEngine) Start(source RelayPCMSource, title, thumbnail string) erro
 	go func() {
 		waitErr := cmd.Wait()
 		e.logf("cmd.Wait() returned: %v", waitErr)
-		e.Stop()
+		e.stopIfCurrent(gen)
 	}()
 
 	return nil
+}
+
+// stopIfCurrent tears the engine down (as Stop does) only if gen is still
+// the generation that is currently active. It is the teardown path for a
+// session's own cmd.Wait() goroutine: if a newer Start() has already
+// replaced this session by the time ffmpeg exits — plausible on a loaded
+// runner, where process-exit and pipe-EOF latency after Stop()'s
+// cancel() can outlast the next Start() — tearing down unconditionally
+// would kill the new session's subscribers instead of the old, exited one.
+// Explicit callers (t.Cleanup(remoteRelay.Stop), Start()'s own leading
+// e.Stop()) go through Stop() directly and always tear down, bumping the
+// generation so any still-pending stopIfCurrent(oldGen) becomes a no-op.
+func (e *relayEngine) stopIfCurrent(gen int) {
+	e.mu.Lock()
+	if gen != e.generation {
+		e.logf("stopIfCurrent: stale generation %d (current %d), skipping teardown", gen, e.generation)
+		e.mu.Unlock()
+		return
+	}
+	e.mu.Unlock()
+	e.Stop()
 }
 
 // pumpStderr relays ffmpeg's stderr line-by-line to the diagnostic hook. In
@@ -264,6 +313,11 @@ func (e *relayEngine) broadcast(chunk []byte) {
 // channel, ending their HTTP responses. Safe to call when nothing is active.
 func (e *relayEngine) Stop() {
 	e.mu.Lock()
+	// Bump unconditionally (even when nothing is active) so that any
+	// stopIfCurrent(gen) still in flight from a previous session's cmd.Wait()
+	// goroutine is guaranteed to see a mismatch and no-op, regardless of
+	// whether this Stop() call itself has anything to tear down.
+	e.generation++
 	if !e.active {
 		e.mu.Unlock()
 		return

--- a/server/app_remote_relay_test.go
+++ b/server/app_remote_relay_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 )
@@ -254,30 +253,22 @@ func TestRemoteRelayEngine_SingleClientReceivesADTSBytes(t *testing.T) {
 }
 
 func TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes(t *testing.T) {
-	// relay_ci_research/notes/ で GitHub Actions 固有の失敗を計測中。
-	// 診断のため一時的に GITHUB_ACTIONS スキップを外し、relayEngine.debugf
-	// 経由で ffmpeg stderr・バイト数・購読者数を t.Logf に出している。
+	// かつて GitHub Actions の ubuntu-latest ランナー上でのみ、両クライアント
+	// とも 0 バイトで再現性よく失敗していた（relay_ci_research/notes/
+	// stale-cmd-wait-teardown.md に詳細）。原因は relayEngine の再入可能性
+	// バグ: Start() が spawn する「ffmpeg 終了を待って Stop() する」ゴルー
+	// チンが自分の属するセッションを区別できておらず、かつ Stop() 側もその
+	// ゴルーチンの完了を待たない。直前のテスト（Single/MultiClient は同じ
+	// パッケージグローバル remoteRelay を共有する）の ffmpeg プロセスの
+	// 終了・パイプ EOF が CI の混雑したランナーで遅延し、次テストの Start()
+	// より後に完了すると、古いセッションの Stop() が新しいセッションの
+	// 購読者を巻き込んで破棄していた。app_remote_relay.go の generation
+	// カウンタ（stopIfCurrent）でこの再入を防止したため、スキップを解除
+	// している。回帰テストは TestRelayEngine_StaleGenerationStopIsNoOp。
 	requireFFmpegForTest(t)
 	newTempRemoteStore(t)
 	withServerMode(t, ModeGUI)
 	token := ensureDeviceAuthToken("dev_test_multi")
-
-	if path, err := exec.LookPath("ffmpeg"); err == nil {
-		if out, verErr := exec.Command(path, "-version").Output(); verErr == nil {
-			firstLine := string(out)
-			if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
-				firstLine = firstLine[:idx]
-			}
-			t.Logf("[diag] ffmpeg path=%s version=%q", path, firstLine)
-		} else {
-			t.Logf("[diag] ffmpeg -version failed: %v", verErr)
-		}
-	} else {
-		t.Logf("[diag] exec.LookPath(ffmpeg) failed: %v", err)
-	}
-
-	remoteRelay.setDebugf(t.Logf)
-	t.Cleanup(func() { remoteRelay.setDebugf(nil) })
 
 	source := newChanRelayPCMSource(44100, 1)
 	if err := remoteRelay.Start(source, "Test Song", ""); err != nil {

--- a/server/app_remote_relay_test.go
+++ b/server/app_remote_relay_test.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
@@ -201,29 +201,30 @@ func TestRemoteRelayEngine_SingleClientReceivesADTSBytes(t *testing.T) {
 }
 
 func TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes(t *testing.T) {
-	// このテストは server パッケージが非 darwin で一切コンパイルできて
-	// いなかった別件のビルド破壊が直った今回、GitHub Actions の
-	// ubuntu-latest ランナー上で初めて実行され、生配信ウィンドウを
-	// 5秒・読み取りデッドラインを20秒まで広げても再現性よく「両クライア
-	// ントとも0バイト」で失敗することを確認した。一方で、同じ Linux
-	// （linux/amd64、Ubuntu 24.04 相当・golang:1.25 系イメージ、-race
-	// 有効、CPU 制限あり/なし両方、count=20 の繰り返し）を Docker で
-	// 再現しようとしたが一度も再現しなかった。単一クライアント版
-	// （TestRemoteRelayEngine_SingleClientReceivesADTSBytes）は同じ CI で
-	// 安定して通っているため、ffmpeg パイプライン自体は機能しており、
-	// GitHub Actions のホスト型ランナーに固有の何か（ネットワーク
-	// サンドボックス等）が2クライアント同時購読の経路だけに影響して
-	// いる可能性が高い。本物のコードのバグである確証が得られないまま
-	// 握りつぶすのを避けるため、CI 上でのみ明示的にスキップし、理由を
-	// ここに残す。ローンチ環境（GitHub Actions）以外では通常どおり
-	// 実行され続ける。
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		t.Skip("GitHub Actions の Linux ランナーでのみ再現する未解明の環境要因で失敗するためスキップ（ローカル/Docker linux-amd64では再現せず）。詳細は本関数冒頭のコメント参照")
-	}
+	// relay_ci_research/notes/ で GitHub Actions 固有の失敗を計測中。
+	// 診断のため一時的に GITHUB_ACTIONS スキップを外し、relayEngine.debugf
+	// 経由で ffmpeg stderr・バイト数・購読者数を t.Logf に出している。
 	requireFFmpegForTest(t)
 	newTempRemoteStore(t)
 	withServerMode(t, ModeGUI)
 	token := ensureDeviceAuthToken("dev_test_multi")
+
+	if path, err := exec.LookPath("ffmpeg"); err == nil {
+		if out, verErr := exec.Command(path, "-version").Output(); verErr == nil {
+			firstLine := string(out)
+			if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
+				firstLine = firstLine[:idx]
+			}
+			t.Logf("[diag] ffmpeg path=%s version=%q", path, firstLine)
+		} else {
+			t.Logf("[diag] ffmpeg -version failed: %v", verErr)
+		}
+	} else {
+		t.Logf("[diag] exec.LookPath(ffmpeg) failed: %v", err)
+	}
+
+	remoteRelay.debugf = t.Logf
+	t.Cleanup(func() { remoteRelay.debugf = nil })
 
 	source := newChanRelayPCMSource(44100, 1)
 	if err := remoteRelay.Start(source, "Test Song", ""); err != nil {

--- a/server/app_remote_relay_test.go
+++ b/server/app_remote_relay_test.go
@@ -140,6 +140,59 @@ func TestRemoteRelayHandler_NoActiveSourceReturns409(t *testing.T) {
 	}
 }
 
+// TestRelayEngine_StaleGenerationStopIsNoOp is a white-box regression test
+// for the reentrancy hazard described in
+// relay_ci_research/notes/stale-cmd-wait-teardown.md: Start()'s trailing
+// `go func(){ cmd.Wait(); e.Stop() }()` used to tear the engine down
+// unconditionally, with no way to tell "my session" apart from "whichever
+// session happens to be active when I finally get scheduled". A slow-to-exit
+// previous ffmpeg process could therefore kill a session that had already
+// replaced it. It does not spawn a real ffmpeg process — that would make the
+// stale-goroutine race itself nondeterministic to test — instead it drives
+// the generation guard (stopIfCurrent) directly against manually-set engine
+// state, which is exactly the mechanism the real cmd.Wait() goroutine
+// exercises.
+func TestRelayEngine_StaleGenerationStopIsNoOp(t *testing.T) {
+	e := newRelayEngine()
+
+	// Simulate session 1 having started (generation 1) and already having
+	// been superseded by session 2 (generation 2, the "current" one).
+	e.mu.Lock()
+	e.generation = 2
+	e.active = true
+	ch := make(chan []byte, 1)
+	e.subs[0] = &relaySubscriber{ch: ch}
+	e.mu.Unlock()
+
+	// Session 1's cmd.Wait() goroutine finally returns and calls
+	// stopIfCurrent(1). It must be a no-op: session 2 is still current.
+	e.stopIfCurrent(1)
+
+	active, _, _ := e.State()
+	if !active {
+		t.Fatalf("stopIfCurrent(stale generation) deactivated the engine, want the current session left running")
+	}
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			t.Fatalf("stopIfCurrent(stale generation) closed the current session's subscriber channel")
+		}
+	default:
+	}
+
+	// Session 2's own cmd.Wait() goroutine returns and calls
+	// stopIfCurrent(2). This must actually tear the engine down.
+	e.stopIfCurrent(2)
+
+	active, _, _ = e.State()
+	if active {
+		t.Fatalf("stopIfCurrent(current generation) left the engine active, want it torn down")
+	}
+	if _, ok := <-ch; ok {
+		t.Fatalf("stopIfCurrent(current generation) left the subscriber channel open, want it closed")
+	}
+}
+
 func TestRemoteRelayEngine_SingleClientReceivesADTSBytes(t *testing.T) {
 	requireFFmpegForTest(t)
 	newTempRemoteStore(t)
@@ -223,8 +276,8 @@ func TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes(t *testing.
 		t.Logf("[diag] exec.LookPath(ffmpeg) failed: %v", err)
 	}
 
-	remoteRelay.debugf = t.Logf
-	t.Cleanup(func() { remoteRelay.debugf = nil })
+	remoteRelay.setDebugf(t.Logf)
+	t.Cleanup(func() { remoteRelay.setDebugf(nil) })
 
 	source := newChanRelayPCMSource(44100, 1)
 	if err := remoteRelay.Start(source, "Test Song", ""); err != nil {


### PR DESCRIPTION
GitHub Actions でのみ再現していた `TestRemoteRelayEngine_MultipleConcurrentClientsBothReceiveBytes` の失敗について真因を特定し、**本番コードのバグ**として修正します。スキップを削除しました。

## 真因（推測ではなく `-race` による実証）

計装を入れて CI に投げた最初の実行で、`-race` が競合を報告しました。**前のテストの ffmpeg stderr 読み取りゴルーチンが、次のテストが `Start()` を呼んだ後も生きていて、再代入されたフィールドを読んでいた**というものです。

`Start()` は末尾で「ffmpeg が終了したらエンジンを畳む」ゴルーチンを起動しますが、`Stop()` は context を cancel するだけで、そのゴルーチンの終了を待ちません。負荷の高い共有ランナーでは ffmpeg の終了とパイプ EOF の遅延が次の `Start()` を追い越し、**古いセッションのゴルーチンが新しいセッションを畳んでいました**。「両クライアント 0 バイト＝エンジン全断」という症状と完全に一致します。

## これは本番のバグでもあります

同じ再入は実運用の経路に存在します。`NotifyYouTubePlaybackState` は曲が変わるたびに中継を再起動し、`Start()` は冒頭で `e.Stop()` を呼びます。**曲を素早く切り替えると、前の ffmpeg の終了通知が新しい LAN 中継を黙って殺します。** 聴いている側からは原因不明で音が止まったように見えるはずです。

## 修正

`relayEngine` に世代カウンタを追加し、`cmd.Wait()` ゴルーチンは `stopIfCurrent(gen)` を通して**自分の世代が現役のときだけ**畳みます。明示的な `Stop()` は常に世代を進めるので、在庫の `stopIfCurrent(oldGen)` は必ず no-op になります。

### レビュー指摘の反映

初版は世代チェックとティアダウンが別々のクリティカルセクションになっており、その隙間に `Start()` が割り込むと新セッションを畳める、同じバグの縮小版が残っていました。`teardownLocked()` を切り出し、**ロックを保持したままチェックからティアダウンまで実行**する形に修正しています。

## 検証

- CI: `go test (linux)` / `go build (windows)` ともに緑（修正後 5 回連続）
- `GITHUB_ACTIONS` スキップを削除
- 診断用の計装は完全に除去（`broadcast`/`pumpADTS` はチャンク毎に呼ばれるホットパスのため、恒久的なログは正当化できない）
- 決定的な回帰テスト `TestRelayEngine_StaleGenerationStopIsNoOp` を追加

## 調査記録

`relay_ci_research/notes/stale-cmd-wait-teardown.md`（棄却した仮説とその証拠、レビュー指摘の追記、`Subscribe`/`unsubscribe`/`State` の点検結果を含む）。

## スコープ外として記録した別件

`remoteRelayHandler` の `State()` →（ロック解放）→ `Subscribe()` にも同じ形の隙間があり、間に `Stop()` が入ると死んだセッションに購読しうる。影響は良性（クライアントが切断までバイトを受け取らないだけ）で、`relayEngine` の再入バグとは別レイヤーのためノートに記録して未修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)