### PR TITLE
ci: swift-cliジョブをmacos-15へ上げてSwiftツールチェーン不一致を解消

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     name: go test (linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # pkg/audio は portaudio を無条件 import しているため、
       # これが無いとパッケージ全体がコンパイルできずテストが「存在しない」扱いになる。
@@ -98,7 +98,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # msys2 shell 内から後続ステップで使うため checkout 自体は shell 指定なしで良いが、
           # defaults.run.shell が全ステップに効くので actions/checkout も msys2 上で動く。
@@ -201,7 +201,7 @@ jobs:
       run:
         working-directory: src/renderer
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:
@@ -224,7 +224,7 @@ jobs:
     name: pytest (lyrics-sync)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:
@@ -253,7 +253,7 @@ jobs:
     # 落とすのではなくランナー側を Swift 6 系がデフォルトの macos-15 に上げる。
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # ツールチェインのバージョンドリフトは「Package.swift が新しいのにランナーが
       # 古い」形で再発しやすい。次に同じ事故が起きたときログから即座に切り分けられる
@@ -271,7 +271,7 @@ jobs:
     name: xcodebuild test (UX-Music-Mobile)
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: List available simulators
         run: xcrun simctl list devices available

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,9 +246,22 @@ jobs:
   # 上の 3 ジョブが必須ゲートで、こちらは macOS ランナーでのみ動く追加の網。
   swift-cli:
     name: swift test (lyrics-sync CLI)
-    runs-on: macos-14
+    # Package.swift が swift-tools-version 6.0 を要求するため、Swift 5.10 までしか
+    # 積んでいない macos-14 では「package が要求する tools version をインストール済みの
+    # バージョンが満たせない」エラーで即死する。開発機は Swift 6.3.2 で動いており、
+    # 依存の WhisperKit も 6.x 系を前提にする可能性が高いので、Package.swift 側を
+    # 落とすのではなくランナー側を Swift 6 系がデフォルトの macos-15 に上げる。
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+
+      # ツールチェインのバージョンドリフトは「Package.swift が新しいのにランナーが
+      # 古い」形で再発しやすい。次に同じ事故が起きたときログから即座に切り分けられる
+      # よう、swift test の直前に実際に使われているバージョンを出しておく。
+      - name: Show toolchain versions
+        run: |
+          swift --version
+          xcodebuild -version
 
       - name: swift test
         working-directory: swift/lyrics-sync


### PR DESCRIPTION
最後まで赤かった `swift test (lyrics-sync CLI)` を修正します。これで**リポジトリ史上初の全ジョブ緑**になります。

## 原因

コードは無関係で、純粋なツールチェーンのバージョン不一致でした。

```
error: 'lyrics-sync': package 'lyrics-sync' is using Swift tools version 6.0.0
       but the installed version is 5.10.0
```

## 対応

`swift-cli` ジョブのランナーを `macos-14` → `macos-15` に変更（実測で Swift 6.1.2 を確認）。

**`Package.swift` の `swift-tools-version` は下げていません。** 開発機は Swift 6.3.2 で動いており、依存の WhisperKit も 6.x 系を前提とする可能性が高いため、CI に合わせて下げると開発・配布している環境と乖離し、テストの意味が薄れます。

`ios-mobile` ジョブは無変更です（`macos-14` のまま）。`xcodebuild` の destination が `iPhone 15` を指定しており、新しいイメージでシミュレータ名が変わるリスクを避けました。緑のままであることも確認済みです。

## 再発防止

`swift test` の直前に `swift --version` / `xcodebuild -version` を出力するステップを追加しました。今回この不一致を突き止めるにはランナーのログを掘る必要がありましたが、以後はバージョンドリフトが一目で分かります。

## 副次的な対応

`actions/checkout` を `@v4` → `@v5` に更新（Node 20 非推奨警告の解消）。Swift ジョブが緑になったことを確認してから別コミットで実施し、更新後も全ジョブ緑を確認済みです。

## 検証

| ジョブ | 結果 |
|---|---|
| `go test (linux)` | success |
| `go build (windows)` | success |
| `vitest (renderer)` | success |
| `pytest (lyrics-sync)` | success |
| `xcodebuild test (UX-Music-Mobile)` | success |
| `swift test (lyrics-sync CLI)` | success |

Swift のテストはツールチェーンが正しくなった時点で自力で通過しました（`ForcedAlignerPipelineTests` 2件）。コード側の問題はありません。ジョブ所要時間は約76秒（依存のビルド込み64秒）で、キャッシュ追加を正当化するほどの遅さではないため見送りました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)